### PR TITLE
Make transactions table

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   has_many    :images
+  has_one     :transaction
   belongs_to  :category
   belongs_to  :sizing
   enum        condition: {

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,35 @@
+class Transaction < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to  :item
+  belongs_to  :seller,  class_name: 'User', foreign_key: :seller_id
+  belongs_to  :buyer,   class_name: 'User', foreign_key: :buyer_id, optional: true
+  belongs_to_active_hash :prefecture
+  enum delivery_method: {
+    pending:      0,
+    mercari_post: 1,
+    yu_mail:      2,
+    letter_pack:  3,
+    reqular_post: 4,
+    kuroneko:     5,
+    yu_pack:      6,
+    click_post:   7,
+    yu_packet:    8
+  }
+  enum bearing: {
+    seller_side: false,
+    buyer_side:  true
+  }
+  enum ship_days: {
+    short:       0,
+    medium:      1,
+    long:        2
+  }
+  enum status: {
+    exhibit:     0,
+    contract:    1,
+    shipped:     2,
+    arrived:     3,
+    thanks:      4,
+    complete:    5
+  }
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,3 +8,21 @@ ja:
         poor:     "やや傷や汚れあり"
         dirty:    "傷や汚れあり"
         bad:      "全体的に状態が悪い"
+    transaction:
+      delivery_method:
+        pending:        "未定"
+        mercari_post:   "らくらくメルカリ便"
+        yu_mail:        "ゆうメール"
+        letter_pack:    "レターパック"
+        reqular_post:   "普通郵便(定形、不定形)"
+        kuroneko:       "クロネコヤマト"
+        yu_pack:        "ゆうパック"
+        click_post:     "クリックポスト"
+        yu_packet:      "ゆうパケット"
+      bearing:
+        seller_side:    "送料込み(出品者負担)"
+        buyer_side:     "着払い(購入者負担)"
+      ship_days:
+        short:          "1~2日で発送"
+        medium:         "2~3日で発送"
+        long:           "4~7日で発送"

--- a/db/migrate/20190927085202_create_transactions.rb
+++ b/db/migrate/20190927085202_create_transactions.rb
@@ -1,0 +1,19 @@
+class CreateTransactions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :transactions do |t|
+      t.references  :item,      foreign_key: true,      null: false
+      t.references  :seller,                            null: false
+      t.references  :buyer
+      t.integer     :delivery_method,                   null: false
+      t.boolean     :bearing,                           null: false
+      t.integer     :ship_days,                         null: false
+      t.integer     :status,                            null: false,    default: 0
+      t.integer     :prefecture_id,                     null: false
+      t.date        :purchased_at
+
+      t.timestamps
+    end
+    add_foreign_key :transactions,  :users, column: :seller_id
+    add_foreign_key :transactions,  :users, column: :buyer_id
+  end
+end

--- a/db/migrate/20190928021417_add_column_to_items.rb
+++ b/db/migrate/20190928021417_add_column_to_items.rb
@@ -1,0 +1,5 @@
+class AddColumnToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :transaction, foreign_key: true, null: false 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_085202) do
+ActiveRecord::Schema.define(version: 2019_09_28_021417) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "ancestry"
@@ -39,12 +39,14 @@ ActiveRecord::Schema.define(version: 2019_09_27_085202) do
     t.integer "condition", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "transaction_id", null: false
     t.index ["brand"], name: "index_items_on_brand"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["condition"], name: "index_items_on_condition"
     t.index ["name"], name: "index_items_on_name"
     t.index ["price"], name: "index_items_on_price"
     t.index ["sizing_id"], name: "index_items_on_sizing_id"
+    t.index ["transaction_id"], name: "index_items_on_transaction_id"
   end
 
   create_table "sizings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -93,6 +95,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_085202) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "sizings"
+  add_foreign_key "items", "transactions"
   add_foreign_key "transactions", "items"
   add_foreign_key "transactions", "users", column: "buyer_id"
   add_foreign_key "transactions", "users", column: "seller_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_043951) do
+ActiveRecord::Schema.define(version: 2019_09_27_085202) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "ancestry"
@@ -54,6 +54,23 @@ ActiveRecord::Schema.define(version: 2019_09_27_043951) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "transactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "seller_id", null: false
+    t.bigint "buyer_id"
+    t.integer "delivery_method", null: false
+    t.boolean "bearing", null: false
+    t.integer "ship_days", null: false
+    t.integer "status", default: 0, null: false
+    t.integer "prefecture_id", null: false
+    t.date "purchased_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["buyer_id"], name: "index_transactions_on_buyer_id"
+    t.index ["item_id"], name: "index_transactions_on_item_id"
+    t.index ["seller_id"], name: "index_transactions_on_seller_id"
+  end
+
   create_table "upload_tests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
     t.datetime "created_at", null: false
@@ -76,4 +93,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_043951) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "sizings"
+  add_foreign_key "transactions", "items"
+  add_foreign_key "transactions", "users", column: "buyer_id"
+  add_foreign_key "transactions", "users", column: "seller_id"
 end


### PR DESCRIPTION
# what

itemの状態管理やuserとの関連を表現するtransactions model、および tableを実装する。
enumによる値の変換や、active_hashを用いたasociationを定義しています。

# why

item出品や、購入・削除等の実装に必要なため。