### PR TITLE
rename transactions table

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   has_many    :images
-  has_one     :transaction
+  has_one     :transact
   belongs_to  :category
   belongs_to  :sizing
   enum        condition: {

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,4 @@
-class Transaction < ApplicationRecord
+class Transact < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to  :item
   belongs_to  :seller,  class_name: 'User', foreign_key: :seller_id

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,7 +8,7 @@ ja:
         poor:     "やや傷や汚れあり"
         dirty:    "傷や汚れあり"
         bad:      "全体的に状態が悪い"
-    transaction:
+    transact:
       delivery_method:
         pending:        "未定"
         mercari_post:   "らくらくメルカリ便"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,6 @@ Rails.application.routes.draw do
   end
 
   # item exhibiting
-  resources :items, only: [:new, :create, :show]
+  # resources :items, only: [:new, :create, :show]
+  # get 'sell'
 end

--- a/db/migrate/20190928033432_remove_column_from_items.rb
+++ b/db/migrate/20190928033432_remove_column_from_items.rb
@@ -1,0 +1,6 @@
+class RemoveColumnFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :items, :transactions
+    remove_reference :items, :transaction
+  end
+end

--- a/db/migrate/20190928034904_rename_transactions_table.rb
+++ b/db/migrate/20190928034904_rename_transactions_table.rb
@@ -1,0 +1,5 @@
+class RenameTransactionsTable < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :transactions, :transacts
+  end
+end

--- a/db/migrate/20190928035348_add_reference_to_items.rb
+++ b/db/migrate/20190928035348_add_reference_to_items.rb
@@ -1,0 +1,5 @@
+class AddReferenceToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :transact, foreign_key: true, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_28_021417) do
+ActiveRecord::Schema.define(version: 2019_09_28_035348) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "ancestry"
@@ -39,14 +39,14 @@ ActiveRecord::Schema.define(version: 2019_09_28_021417) do
     t.integer "condition", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "transaction_id", null: false
+    t.bigint "transact_id", null: false
     t.index ["brand"], name: "index_items_on_brand"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["condition"], name: "index_items_on_condition"
     t.index ["name"], name: "index_items_on_name"
     t.index ["price"], name: "index_items_on_price"
     t.index ["sizing_id"], name: "index_items_on_sizing_id"
-    t.index ["transaction_id"], name: "index_items_on_transaction_id"
+    t.index ["transact_id"], name: "index_items_on_transact_id"
   end
 
   create_table "sizings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2019_09_28_021417) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "transactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "transacts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "item_id", null: false
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
@@ -68,9 +68,9 @@ ActiveRecord::Schema.define(version: 2019_09_28_021417) do
     t.date "purchased_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["buyer_id"], name: "index_transactions_on_buyer_id"
-    t.index ["item_id"], name: "index_transactions_on_item_id"
-    t.index ["seller_id"], name: "index_transactions_on_seller_id"
+    t.index ["buyer_id"], name: "index_transacts_on_buyer_id"
+    t.index ["item_id"], name: "index_transacts_on_item_id"
+    t.index ["seller_id"], name: "index_transacts_on_seller_id"
   end
 
   create_table "upload_tests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -95,8 +95,8 @@ ActiveRecord::Schema.define(version: 2019_09_28_021417) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "sizings"
-  add_foreign_key "items", "transactions"
-  add_foreign_key "transactions", "items"
-  add_foreign_key "transactions", "users", column: "buyer_id"
-  add_foreign_key "transactions", "users", column: "seller_id"
+  add_foreign_key "items", "transacts"
+  add_foreign_key "transacts", "items"
+  add_foreign_key "transacts", "users", column: "buyer_id"
+  add_foreign_key "transacts", "users", column: "seller_id"
 end


### PR DESCRIPTION
# what

transactionsテーブルをtransactテーブルに命名変更する

# why

transactがactiverecordのメソッド名と競合するため。