### PR TITLE
Item editing page

### DIFF
--- a/app/assets/javascripts/item_exhibit.js
+++ b/app/assets/javascripts/item_exhibit.js
@@ -90,8 +90,8 @@ $(function() {
     }
     var fee = Math.floor(price*0.1);
     var profit = Math.ceil(price*0.9);
-    $('#commission-fee').append(commaSeparated(fee));
-    $('#your-profit').append(commaSeparated(profit));
+    $('#commission-fee').append(`¥ ${commaSeparated(fee)}`);
+    $('#your-profit').append(`¥ ${commaSeparated(profit)}`);
   }
 
 

--- a/app/assets/stylesheets/modules/devise/login-page.scss
+++ b/app/assets/stylesheets/modules/devise/login-page.scss
@@ -48,11 +48,8 @@
         position: absolute;
         top: 42px;
         left:80px;
-        font-size: 30px;
-        
+        font-size: 30px;       
       }
-      
-
       &__Google{
         color: #333;
         font-size: 14px;
@@ -108,7 +105,9 @@
         text-align: left;
         font-size: 14px;
       }
-
+      &__recaptcha {
+        margin-top: 20px;
+      }
     }
     
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -98,10 +98,6 @@ class ItemsController < ApplicationController
     redirect_to user_sessions_new_path
   end
 
-  def move_to_root_path
-
-  end
-
   def current_user_is_seller?
     unless current_user.id == @item.seller.id
       flash.now[:danger] = '不正なリクエストです' 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,7 +49,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
+    if @item.transact.status_before_type_cast == 0
+      @item.destroy
+    else
+      flash.now[:alert] = '不正な操作です'
+    end
     redirect_to mypage_path
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,5 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   layout "application-user"
-  # before_action :check_captcha, only: :phone_number
   before_action :configure_sign_up_params, only: [:create]
   before_action :reject_signed_in_user, except: [:complete]
   # before_action :configure_account_update_params, only: [:update]

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -93,4 +93,12 @@ module ItemsHelper
       content_tag(:div, '', id: 'delivery_method-wrapper')
     end
   end
+
+  def modify_button_message(action)
+    if %w(edit update).include?(action)
+      %w(変更する キャンセル)
+    else
+      %w(出品する もどる)
+    end
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   has_many    :images, dependent: :destroy
   accepts_nested_attributes_for :images
   has_one     :transact, dependent: :destroy, class_name: 'Transact', inverse_of: :item
-  accepts_nested_attributes_for :transact
+  accepts_nested_attributes_for :transact, update_only: true
   belongs_to  :category
   belongs_to  :sizing, optional: true
   delegate    :seller, :buyer, to: :transact

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -13,8 +13,8 @@
             = f.email_field :email, autofocus: true,placeholder:"メールアドレス"
           .field-input
             = f.password_field :password, autocomplete: "off",placeholder:"パスワード"
-          .login-page__login-box__login__recaptha
-          ろぼっとは未実装
+          .login-page__login-box__login__recaptcha
+            = recaptcha_tags
           .actions
             = f.submit "ログイン", class: 'btn'
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -109,18 +109,20 @@
             #your-profit.items-forms__price--profit
               \-
       .items-container__inner--content
-        %p
-          = link_to "禁止されている出品", "#"
-          、
-          = link_to "行為", "#"
-          を必ずご確認ください。
-        %p
-          またブランド品でシリアルナンバー等がある場合はご記載ください。
-          = link_to "偽ブランドの販売"
-          は犯罪であり処罰される可能性があります。
-        %p
-          また、出品をもちまして
-          = link_to "加盟店規約", ""
-          に同意したことになります。
-        = f.submit "出品する", class: "items-forms__content__submit"
-        = link_to "もどる", :back, class: 'items-forms__content__return'
+        - unless %w(edit update).include?(controller.action_name)
+          %p
+            = link_to "禁止されている出品", "#"
+            、
+            = link_to "行為", "#"
+            を必ずご確認ください。
+          %p
+            またブランド品でシリアルナンバー等がある場合はご記載ください。
+            = link_to "偽ブランドの販売"
+            は犯罪であり処罰される可能性があります。
+          %p
+            また、出品をもちまして
+            = link_to "加盟店規約", ""
+            に同意したことになります。
+        - message = modify_button_message(controller.action_name)
+        = f.submit message[0], class: "items-forms__content__submit"
+        = link_to message[1], :back, class: 'items-forms__content__return'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -126,7 +126,7 @@
 //アイテム編集・削除
 - if (current_user == @item.seller) && (@item.transact.status_before_type_cast == 0)
   .items-status
-    = link_to edit_item_path, class: 'items-status__edit' do
+    = link_to edit_item_path(@item), class: 'items-status__edit' do
       商品の編集
     %p or
     .items-status__exhibit

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -261,19 +261,19 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth :facebook,
-                  # Rails.application.credentials.facebook[:access_key_id],
-                  # Rails.application.credentials.facebook[:secret_access_key],
-                  "1111111111111",
-                  "1111111111111",
+                  Rails.application.credentials.facebook[:access_key_id],
+                  Rails.application.credentials.facebook[:secret_access_key],
+                  # "1111111111111",
+                  # "1111111111111",
                   scope: 'email',
                   info_fields: 'email',
                   display: 'popup'
 
   config.omniauth :google_oauth2,
-                  # Rails.application.credentials.google[:access_key_id],
-                  # Rails.application.credentials.google[:secret_access_key],
-                  "1111111111111",
-                  "1111111111111",
+                  Rails.application.credentials.google[:access_key_id],
+                  Rails.application.credentials.google[:secret_access_key],
+                  # "1111111111111",
+                  # "1111111111111",
                   scope: 'email'
 
   # ==> Warden configuration

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,6 +1,6 @@
 Recaptcha.configure do |config|
-  # config.site_key = Rails.application.credentials.recaptcha[:site_key]
-  # config.secret_key = Rails.application.credentials.recaptcha[:secret_key]
-  config.site_key = "1111111111"
-  config.secret_key = "1111111111"
+  config.site_key = Rails.application.credentials.recaptcha[:site_key]
+  config.secret_key = Rails.application.credentials.recaptcha[:secret_key]
+  # config.site_key = "1111111111"
+  # config.secret_key = "1111111111"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   # item exhibiting
 
   get 'sell', to: 'items#new', as: 'item_exhibit'
-  resources :items, only: [:index, :new, :create, :show, :edit, :destroy]
+  resources :items
   
   # 商品取引
   get 'transacts/:id', to:'transacts#buy', as: 'transacts'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   # item exhibiting
 
   get 'sell', to: 'items#new', as: 'item_exhibit'
-  resources :items
+  resources :items, except: [:new]
   
   # 商品取引
   get 'transacts/:id', to:'transacts#buy', as: 'transacts'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2019_10_07_153744) do
     t.text "profile"
     t.integer "card_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["phone_number"], name: "index_users_on_phone_number", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,7 +1,44 @@
 require 'rails_helper'
 
-# RSpec.describe ItemsController, type: :controller do
-#   let(:item) { create(:item) }
+RSpec.describe ItemsController, type: :controller do
+  let(:item) { create(:item) }
+  let(:another_item) { create(:item) }
+  let(:user) { create(:user) }
+  let(:images) { create_list(:image, 3) }
+  let(:valid_params) {{
+    item: {
+      name: 'hoge',
+      description: 'hogehoge',
+      category_id: 3,
+      sizing_id: 3,
+      condition: 'normal',
+      price: 3000,
+      transact_attributes: {
+        bearing: 'seller_side',
+        delivery_method: 'pending',
+        prefecture_id: 4,
+        ship_days: 'short'
+      }
+    },
+    image_ids: images.map{ |img| img.id }.join(',')
+  }}
+  let(:invalid_params) {{
+    item: {
+      name: '',
+      description: '',
+      category_id: 3,
+      sizing_id: 3,
+      condition: 'normal',
+      price: 3000,
+      transact_attributes: {
+        bearing: 'seller_side',
+        delivery_method: 'pending',
+        prefecture_id: 4,
+        ship_days: 'short'
+      }
+    },
+    image_ids: ''
+  }}
 
   # describe 'GET #index' do
   #   # it "@itemsに人気カテゴリー・ブランドのitemレコードが紐付いている" do
@@ -37,17 +74,212 @@ require 'rails_helper'
   # end
 
   describe 'DELETE #destroy' do
-    let!(:item) { FactoryBot.create :item }
-
-    it 'itemテーブルからitemレコードを削除する' do
-      expect {
-        delete :destroy, params: { id: item.id }
-      }.to change(Item, :count).by(-1)
+    context 'when the user is signed in and is the seller' do
+      before do
+        sign_in item.seller
+      end
+      context 'as if the status of the item is exhibit' do
+        subject { delete :destroy, params: { id: item.id }}
+        it 'destroys the item' do
+          expect{subject}.to change(Item, :count).by(-1)
+        end
+        it 'redirects to the mypage_path' do
+          is_expected.to redirect_to(mypage_path)
+        end
+      end
+      context 'as if the status of the item is not exhibit' do
+        subject { 
+          item.transact.update(status: 3)
+          delete :destroy, params: { id: item.id }
+        }
+        it 'does not destroy the item' do
+          expect{subject}.to change(Item, :count).by(0)
+        end
+        it 'redirects to the mypage_path' do
+          is_expected.to redirect_to(root_path)
+        end
+      end
     end
-
-    it '商品削除後にマイページに遷移する' do
-      delete :destroy, params: { id: item.id}
-      expect( response ).to redirect_to(mypage_path)
+    context 'when the user is signed in but is not the seller' do
+      before do
+        sign_in item.seller
+      end
+      subject {
+        delete :destroy, params: { id: another_item.id }
+      }
+      it 'does not destroy the item' do
+        # another_itemを生成するため1つ増える
+        expect{subject}.to change(Item, :count).by(1)
+      end
+      it 'redirect to the root_path' do
+        is_expected.to redirect_to(root_path)
+      end
+    end
+    context 'when the user is not signed in' do
+      subject {
+        delete :destroy, params: { id: item.id }
+      }
+      it 'does not destroy the item' do
+        # itemを生成するため一つ増える
+        expect{subject}.to change(Item, :count).by(1)
+      end
+      it 'redirect to the user_session_new_path' do
+        is_expected.to redirect_to(user_sessions_new_path)
+      end
     end
   end
+
+  describe 'GET #new' do
+    context 'when the user is signed in' do
+      before do
+        sign_in user
+        get :new
+      end
+      it 'renders the :new template' do
+        expect(response).to render_template :new
+      end
+      it 'assigns empty item to @item' do
+        expect(assigns(:item)).to be_a_new Item
+      end
+      it 'assigns empty transact to @item.transact' do
+        expect(assigns(:item).transact).to be_a_new Transact
+      end
+    end
+
+    context 'when the user is not signed in' do
+      before do
+        get :new
+      end
+      it 'redirects to the login page if user not signed in' do
+        expect(response).to redirect_to(user_sessions_new_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when the user is signed in' do
+      before do
+        sign_in user
+      end
+
+      it 'creates a item with valid params' do
+        expect {
+          post :create, params: valid_params
+        }.to change(Item, :count).by(1)
+      end
+      it 'does not create a item with invalid_params' do
+        expect {
+          post :create, params: invalid_params
+        }.to change(Item, :count).by(0)
+      end
+      it 'redirects to the item_path(@item) if successed' do
+        post :create, params: valid_params
+        expect(response).to redirect_to(item_path(assigns(:item)))
+      end
+      it 'assigns the user as seller' do
+        post :create, params: valid_params
+        expect(assigns(:item).seller).to eq user
+      end
+    end
+
+    context 'when the user is not signed in' do
+      before do
+        get :create
+      end
+
+      it 'redirects to the login page if user not signed in' do
+        expect(response).to redirect_to(user_sessions_new_path)
+      end
+    end
+
+  end
+
+  describe 'GET #edit' do
+    before do
+      sign_in item.seller
+    end
+
+    context 'when the user is signed in and is the seller' do
+      subject { 
+        get :edit, params: { id: item.id }
+      }
+
+      it 'renders the :new template' do
+        is_expected.to render_template :new
+      end
+    end
+
+    context 'when the user is signed in but is not the seller' do
+      subject{
+        get :edit, params: { id: another_item.id }
+      }
+
+      it 'redirects to the top page' do
+        is_expected.to redirect_to(root_path)
+      end
+    end
+
+    context 'when the user is not signed in' do
+      before do
+        sign_out item.seller
+        get :edit, params: { id: item.id }
+      end
+
+      it 'redirects to the login page if user not signed in' do
+        expect(response).to redirect_to(user_sessions_new_path)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    before do
+      sign_in item.seller
+    end
+
+    context 'when the user is signed in and is the seller' do
+      context 'with valid params' do
+        subject {
+          patch :update, params: valid_params.merge!(id: item.id)
+        }
+        it 'updates the item' do
+          subject
+          expect(assigns(:item).reload.price).not_to eq item.price
+        end
+        it 'redirects to the :show' do
+          is_expected.to redirect_to(item_path(item))
+        end
+      end
+      context 'with invalid params' do
+        subject {
+          patch :update, params: invalid_params.merge!(id: item.id)
+        }
+        it 'does not update item' do
+          subject
+          expect(assigns(:item).reload.price).to eq item.price
+        end
+        it 'renders the :new' do
+          is_expected.to render_template :new
+        end
+      end
+    end
+
+    context 'when the user is signed in but is not the seller' do
+      subject {get :edit, params: { id: another_item.id }}
+      it 'redirects to the top page' do
+        is_expected.to redirect_to(root_path)
+      end
+    end
+
+    context 'when the user is not signed in' do
+      before do
+        sign_out item.seller
+        get :edit, params: { id: item.id }
+      end
+
+      it 'redirects to the login page if user not signed in' do
+        expect(response).to redirect_to(user_sessions_new_path)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
# what

商品編集ページ、および機能の実装
- items/newのviewを編集ページでも仕様できるように修正
- edit,update,destroyアクションにおいて、currentユーザがitemの出品者でない場合にトップページにリダイレクトさせる
- edit,update,destroyアクションにおいて、itemに紐づくtransactのstatusが"pending"でない場合にトップページにリダイレクトさせる
- new, create, edit, update, destroyアクションの単体テストを上記仕様をみたすように修正

単体テスト実施結果
[![Image from Gyazo](https://i.gyazo.com/dc27510d3a3a9121160c8ab268833071.png)](https://gyazo.com/dc27510d3a3a9121160c8ab268833071)

# why

ユーザが出品した商品の情報を、取引に影響を与えない範囲で編集できるようにする。このとき、悪意あるユーザが他のユーザの商品を不正に操作できないよう、また取引中の商品の情報を改ざんすることができないように配慮する必要がある。

